### PR TITLE
Fix integer overflow in nps output

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -175,7 +175,7 @@ void search::Search::worker(std::ostream& out) {
 
 		out << " nodes " << numnodes;
 		out << " time " << elapsed_iter();
-		out << " nps " << (numnodes * 1000) / (elapsed_iter() + 1);
+		out << " nps " << ((unsigned long) numnodes * 1000) / (elapsed_iter() + 1);
 		out << " score " << score::to_uci(value);
 		out << " pv " << next_pv.to_string();
 		out << "\n";


### PR DESCRIPTION
When node count is high (> 2147483) an expression used in nps calcuation overflows the integer type and outputs a negative nps. This PR adds a cast to ulong to prevent the overflow.

Closes #4